### PR TITLE
Limit log buf size & autocompletion script & HTTP basic auth for JSON API & various tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
     - 1.6.2
-    - tip
+    - 1.7
 
 install:
     - go get github.com/stretchr/testify/assert

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
     - go get github.com/stretchr/testify/assert
     - go get github.com/sjtug/lug
 
-script: go test github.com/sjtug/lug/worker github.com/sjtug/lug/manager github.com/sjtug/lug/config
+script: go test github.com/sjtug/lug/worker github.com/sjtug/lug/manager github.com/sjtug/lug/config github.com/sjtug/lug/helper

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4,8 +4,8 @@
 	"GodepVersion": "v74",
 	"Packages": [
 		".",
-		"./worker",
 		"./manager",
+		"./worker",
 		"./config"
 	],
 	"Deps": [
@@ -35,6 +35,10 @@
 		{
 			"ImportPath": "github.com/dustin/go-humanize",
 			"Rev": "2fcb5204cdc65b4bec9fd0a87606bb0d0e3c54e8"
+		},
+		{
+			"ImportPath": "github.com/goji/httpauth",
+			"Rev": "2da839ab0f4df05a6db5eb277995589dadbd4fb9"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/autocompletion/zsh/_lug
+++ b/autocompletion/zsh/_lug
@@ -1,0 +1,12 @@
+#compdef lug
+local -a options arguments
+#options=('-c:Path of config.yaml' '-cert:Cert for JSON API' '-key:Key for JSON API' '-j:JSON API Address' '-license:Prints license' '-v:Prints version of lug' '-h:Show help')
+#_describe 'values' options
+_arguments '-c[Path of config]:path_of_config:->config' '-cert[Cert for JSON API]:cert:_files' '-key[Key for JSON API]:key:_files' '-j[JSON API Address]:jaddr' '-license[License]' '-v[Version of lug]' '-h[Show help]'
+
+case "$state" in
+    config)
+        local -a configs
+        configs=( *.{yml,yaml} )
+        _multi_parts / configs
+esac

--- a/autocompletion/zsh/_lug
+++ b/autocompletion/zsh/_lug
@@ -2,7 +2,7 @@
 local -a options arguments
 #options=('-c:Path of config.yaml' '-cert:Cert for JSON API' '-key:Key for JSON API' '-j:JSON API Address' '-license:Prints license' '-v:Prints version of lug' '-h:Show help')
 #_describe 'values' options
-_arguments '-c[Path of config]:path_of_config:->config' '-cert[Cert for JSON API]:cert:_files' '-key[Key for JSON API]:key:_files' '-j[JSON API Address]:jaddr' '-license[License]' '-v[Version of lug]' '-h[Show help]'
+_arguments '-c[Path of config]:path_of_config:->config' '-cert[Cert for JSON API]:cert:_files' '-key[Key for JSON API]:key:_files' '-j[JSON API Address]:jaddr' '-license[License]' '-v[Version of lug]' '-h[Show help]' '-u[User for JSON API]' '-p[Password for JSON API]'
 
 case "$state" in
     config)

--- a/autocompletion/zsh/usage.md
+++ b/autocompletion/zsh/usage.md
@@ -1,0 +1,1 @@
+Copy `_lug` to an arbitrary directory(e.g. `~/zsh-completion`), then add the directory to your `fpath` in `.zshrc`: `fpath=(~/zsh-completion $fpath)`.

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -1,0 +1,55 @@
+package helper
+
+import (
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestMaxLengthStringSliceAdaptor(t *testing.T) {
+	assert := assert.New(t)
+	raw := []string{"foo", "bar"}
+	mlss := NewMaxLengthStringSliceAdaptor(raw, 3)
+	news := mlss.GetAll()
+	assert.True(reflect.DeepEqual(raw, news))
+	assert.Equal(2, mlss.Len())
+	assert.Equal(3, mlss.MaxLen())
+
+	raw[1] = "foobar"
+	news = mlss.GetAll()
+	assert.True(reflect.DeepEqual(raw, news), "Raw=%v\tMLSS=%v", raw, mlss)
+
+	mlss.Put("2")
+	assert.Equal(3, mlss.Len())
+	assert.True(reflect.DeepEqual([]string{"foo", "foobar", "2"}, mlss.GetAll()))
+	assert.False(reflect.DeepEqual(mlss, raw))
+
+	mlss.Put("3")
+	assert.Equal(3, mlss.Len())
+	assert.True(reflect.DeepEqual([]string{"foobar", "2", "3"}, mlss.GetAll()))
+	assert.False(reflect.DeepEqual(mlss, raw))
+}
+
+func TestMaxLengthSlice(t *testing.T) {
+	assert := assert.New(t)
+	raw := []string{"foo", "bar"}
+	mlss := NewMaxLengthSlice(raw, 3)
+	news := mlss.GetAll()
+	assert.True(reflect.DeepEqual(raw, news))
+	assert.Equal(2, mlss.Len())
+	assert.Equal(3, mlss.MaxLen())
+
+	raw[1] = "foobar"
+	news = mlss.GetAll()
+	assert.True(reflect.DeepEqual([]string{"foo", "bar"}, news))
+
+	mlss.Put("2")
+	assert.Equal(3, mlss.Len())
+	assert.True(reflect.DeepEqual([]string{"foo", "bar", "2"}, mlss.GetAll()), "MLSS=%v", mlss.GetAll())
+	assert.True(reflect.DeepEqual([]string{"foo", "foobar"}, raw))
+
+	mlss.Put("3")
+	assert.Equal(3, mlss.Len())
+	assert.True(reflect.DeepEqual([]string{"bar", "2", "3"}, mlss.GetAll()))
+	assert.True(reflect.DeepEqual([]string{"foo", "foobar"}, raw))
+}

--- a/helper/max_length_slice.go
+++ b/helper/max_length_slice.go
@@ -1,0 +1,51 @@
+package helper
+
+import "sync"
+
+type MaxLengthStringSliceAdaptor struct {
+	s      []string
+	maxlen int
+	lock   sync.Mutex
+}
+
+// Create an adaptor for given string slice
+func NewMaxLengthStringSliceAdaptor(s []string, maxlen int) *MaxLengthStringSliceAdaptor {
+	return &MaxLengthStringSliceAdaptor{
+		s:      s,
+		maxlen: maxlen,
+	}
+}
+
+func (m MaxLengthStringSliceAdaptor) MaxLen() int {
+	return m.maxlen
+}
+
+func (m *MaxLengthStringSliceAdaptor) Put(str string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.s = append(m.s, str)
+	if len(m.s) > m.MaxLen() {
+		m.s = m.s[1:]
+	}
+}
+
+func (m MaxLengthStringSliceAdaptor) GetAll() []string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	result := make([]string, len(m.s))
+	copy(result, m.s)
+	return result
+}
+
+func (m MaxLengthStringSliceAdaptor) Len() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return len(m.s)
+}
+
+// Copy and init a new max length string slice
+func NewMaxLengthSlice(s []string, maxlen int) *MaxLengthStringSliceAdaptor {
+	news := make([]string, len(s))
+	copy(news, s)
+	return NewMaxLengthStringSliceAdaptor(news, maxlen)
+}

--- a/helper/max_length_slice.go
+++ b/helper/max_length_slice.go
@@ -7,7 +7,7 @@ import "sync"
 type MaxLengthStringSliceAdaptor struct {
 	s      []string
 	maxlen int
-	lock   sync.Mutex
+	lock   sync.RWMutex
 }
 
 // NewMaxLengthStringSliceAdaptor creates an adaptor for given string slice
@@ -42,8 +42,8 @@ func (m *MaxLengthStringSliceAdaptor) Put(str string) {
 
 // GetAll creates a duplicate of current slice and returns it
 func (m MaxLengthStringSliceAdaptor) GetAll() []string {
-	m.lock.Lock()
-	defer m.lock.Unlock()
+	m.lock.RLock()
+	defer m.lock.RUnlock()
 	result := make([]string, len(m.s))
 	copy(result, m.s)
 	return result
@@ -51,8 +51,8 @@ func (m MaxLengthStringSliceAdaptor) GetAll() []string {
 
 // Len returns current length of slice
 func (m MaxLengthStringSliceAdaptor) Len() int {
-	m.lock.Lock()
-	defer m.lock.Unlock()
+	m.lock.RLock()
+	defer m.lock.RUnlock()
 	return len(m.s)
 }
 

--- a/helper/max_length_slice.go
+++ b/helper/max_length_slice.go
@@ -2,13 +2,15 @@ package helper
 
 import "sync"
 
+// MaxLengthStringSliceAdaptor wrap the given slice with several methods for MaxLenSlice.
+// Note that this adaptor does not own that slice at all, so keep the content of slice unchanged!
 type MaxLengthStringSliceAdaptor struct {
 	s      []string
 	maxlen int
 	lock   sync.Mutex
 }
 
-// Create an adaptor for given string slice
+// NewMaxLengthStringSliceAdaptor creates an adaptor for given string slice
 func NewMaxLengthStringSliceAdaptor(s []string, maxlen int) *MaxLengthStringSliceAdaptor {
 	return &MaxLengthStringSliceAdaptor{
 		s:      s,
@@ -16,10 +18,12 @@ func NewMaxLengthStringSliceAdaptor(s []string, maxlen int) *MaxLengthStringSlic
 	}
 }
 
+// MaxLen returns the maximum length of given maxlenslice
 func (m MaxLengthStringSliceAdaptor) MaxLen() int {
 	return m.maxlen
 }
 
+// Put adds a new item into slice, and may remove exceeded item(s)
 func (m *MaxLengthStringSliceAdaptor) Put(str string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -29,6 +33,7 @@ func (m *MaxLengthStringSliceAdaptor) Put(str string) {
 	}
 }
 
+// GetAll creates a duplicate of current slice and returns it
 func (m MaxLengthStringSliceAdaptor) GetAll() []string {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -37,13 +42,14 @@ func (m MaxLengthStringSliceAdaptor) GetAll() []string {
 	return result
 }
 
+// Len returns current length of slice
 func (m MaxLengthStringSliceAdaptor) Len() int {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return len(m.s)
 }
 
-// Copy and init a new max length string slice
+// NewMaxLengthSlice copies and inits a new max length string slice
 func NewMaxLengthSlice(s []string, maxlen int) *MaxLengthStringSliceAdaptor {
 	news := make([]string, len(s))
 	copy(news, s)

--- a/helper/max_length_slice.go
+++ b/helper/max_length_slice.go
@@ -12,10 +12,12 @@ type MaxLengthStringSliceAdaptor struct {
 
 // NewMaxLengthStringSliceAdaptor creates an adaptor for given string slice
 func NewMaxLengthStringSliceAdaptor(s []string, maxlen int) *MaxLengthStringSliceAdaptor {
-	return &MaxLengthStringSliceAdaptor{
+	result := &MaxLengthStringSliceAdaptor{
 		s:      s,
 		maxlen: maxlen,
 	}
+	result.removeExceededItems()
+	return result
 }
 
 // MaxLen returns the maximum length of given maxlenslice
@@ -23,14 +25,19 @@ func (m MaxLengthStringSliceAdaptor) MaxLen() int {
 	return m.maxlen
 }
 
+// Use it when you acquire the lock
+func (m *MaxLengthStringSliceAdaptor) removeExceededItems() {
+	if len(m.s) > m.MaxLen() {
+		m.s = m.s[len(m.s)-m.MaxLen():]
+	}
+}
+
 // Put adds a new item into slice, and may remove exceeded item(s)
 func (m *MaxLengthStringSliceAdaptor) Put(str string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.s = append(m.s, str)
-	if len(m.s) > m.MaxLen() {
-		m.s = m.s[1:]
-	}
+	m.removeExceededItems()
 }
 
 // GetAll creates a duplicate of current slice and returns it

--- a/license.go
+++ b/license.go
@@ -29,35 +29,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-==> ./vendor/github.com/op/go-logging/LICENSE <==
-Copyright (c) 2013 Örjan Persson. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 ==> ./vendor/github.com/stretchr/testify/LICENSE <==
 Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
 
@@ -178,6 +149,28 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+==> ./vendor/github.com/goji/httpauth/LICENSE <==
+Copyright (c) 2014 Carl Jackson (carl@avtok.com), Matt Silverlock (matt@eatsleeprepeat.net)
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==> ./vendor/github.com/ant0ine/go-json-rest/LICENSE <==
 Copyright (c) 2013-2016 Antoine Imbert

--- a/main.go
+++ b/main.go
@@ -74,8 +74,11 @@ func prepareLogger(logLevel log.Level, logStashAddr string) {
 	}
 }
 
-func main() {
-	flags := getFlags()
+var cfg config.Config
+var flags CommandFlags
+
+func init() {
+	flags = getFlags()
 
 	if flags.version {
 		fmt.Print(lugVersionInfo)
@@ -94,16 +97,17 @@ func main() {
 		return
 	}
 
-	cfg := config.Config{}
+	cfg = config.Config{}
 	err = cfg.Parse(dat)
 	prepareLogger(cfg.LogLevel, cfg.LogStashAddr)
-
 	log.Info("Starting...")
 	log.Debugf("%+v\n", cfg)
 	if err != nil {
 		panic(err)
 	}
+}
 
+func main() {
 	m, err := manager.NewManager(&cfg)
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/manager"
+	"github.com/goji/httpauth"
 )
 
 const (
@@ -42,6 +43,8 @@ type CommandFlags struct {
 	jsonAPIAddr string
 	certFile    string
 	keyFile     string
+	apiUser     string
+	apiPassword string
 }
 
 // parse command line options and return CommandFlags
@@ -53,6 +56,8 @@ func getFlags() (flags CommandFlags) {
 	flag.StringVar(&flags.jsonAPIAddr, "j", ":7001", "JSON API Address")
 	flag.StringVar(&flags.certFile, "cert", "", "HTTPS Cert file of JSON API")
 	flag.StringVar(&flags.keyFile, "key", "", "HTTPS Key file of JSON API")
+	flag.StringVar(&flags.apiUser, "u", "", "User for authentication of JSON API")
+	flag.StringVar(&flags.apiPassword, "p", "", "Password for authentication of JSON API")
 	flag.Parse()
 	return
 }
@@ -104,13 +109,25 @@ func main() {
 		panic(err)
 	}
 	jsonapi := manager.NewRestfulAPI(m)
+	handler := jsonapi.GetAPIHandler()
+	if flags.apiUser != "" && flags.apiPassword !="" {
+		auth := httpauth.BasicAuth(httpauth.AuthOptions{
+			Realm: "Require authentication",
+			User: flags.apiUser,
+			Password: flags.apiPassword,
+		})
+		handler = auth(handler)
+	}
 	if flags.keyFile == "" || flags.certFile == "" {
+		if flags.apiUser != "" && flags.apiPassword != "" {
+			log.Warn("JSON API with HTTP auth without TLS/SSL is vulnerable")
+		}
 		log.Infof("Http JSON API listening on %s", flags.jsonAPIAddr)
-		go http.ListenAndServe(flags.jsonAPIAddr, jsonapi.GetAPIHandler())
+		go http.ListenAndServe(flags.jsonAPIAddr, handler)
 	} else {
 		log.Infof("Https JSON API listening on %s with certfile %s and keyfile %s", flags.jsonAPIAddr,
 			flags.certFile, flags.keyFile)
-		go http.ListenAndServeTLS(flags.jsonAPIAddr, flags.certFile, flags.keyFile, jsonapi.GetAPIHandler())
+		go http.ListenAndServeTLS(flags.jsonAPIAddr, flags.certFile, flags.keyFile, handler)
 	}
 
 	m.Run()

--- a/manager/json_rest.go
+++ b/manager/json_rest.go
@@ -6,16 +6,19 @@ import (
 	"net/http"
 )
 
+// RestfulAPI is a JSON-like API of given manager
 type RestfulAPI struct {
 	manager *Manager
 }
 
+// NewRestfulAPI returns a pointer to RestfulAPI of given manager
 func NewRestfulAPI(m *Manager) *RestfulAPI {
 	return &RestfulAPI{
 		manager: m,
 	}
 }
 
+// GetAPIHandler returns handler that could be used for http package
 func (r *RestfulAPI) GetAPIHandler() http.Handler {
 	api := rest.NewApi()
 	api.Use(rest.DefaultDevStack...)
@@ -36,7 +39,6 @@ func (r *RestfulAPI) getManagerStatus(w rest.ResponseWriter, req *rest.Request) 
 	status := r.manager.GetStatus()
 	w.WriteJson(status)
 }
-
 
 func (r *RestfulAPI) startManager(w rest.ResponseWriter, req *rest.Request) {
 	r.manager.Start()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -2,9 +2,9 @@
 package manager
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"strconv"
 	"time"
-	log "github.com/Sirupsen/logrus"
 
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/worker"
@@ -76,7 +76,12 @@ func (m *Manager) Run() {
 				log.Info("Start polling workers")
 				for i, worker := range m.workers {
 					wStatus := worker.GetStatus()
-					log.Debugf("worker %d: %+v", i, wStatus)
+					log.Debugf("worker %d: Idle: %v. Result: %v. Last finished: %v",
+						i,
+						wStatus.Idle,
+						wStatus.Result,
+						wStatus.LastFinished,
+					)
 					if !wStatus.Idle {
 						continue
 					}

--- a/scripts/savedep.sh
+++ b/scripts/savedep.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-godep save . ./manager ./worker ./config
+godep save . ./manager ./worker ./config ./helper

--- a/vendor/github.com/goji/httpauth/.travis.yml
+++ b/vendor/github.com/goji/httpauth/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+sudo: false
+
+matrix:
+  include:
+    - go: 1.2
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+  allow_failures:
+    - go: tip
+
+install:
+  - # skip
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go vet $(go list ./... | grep -v /vendor/)
+  - go test -v -race ./...

--- a/vendor/github.com/goji/httpauth/LICENSE
+++ b/vendor/github.com/goji/httpauth/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014 Carl Jackson (carl@avtok.com), Matt Silverlock (matt@eatsleeprepeat.net)
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/goji/httpauth/README.md
+++ b/vendor/github.com/goji/httpauth/README.md
@@ -1,0 +1,163 @@
+# goji/httpauth [![GoDoc](https://godoc.org/github.com/goji/httpauth?status.svg)](https://godoc.org/github.com/goji/httpauth) [![Build Status](https://travis-ci.org/goji/httpauth.svg)](https://travis-ci.org/goji/httpauth)
+
+`httpauth` currently provides [HTTP Basic Authentication middleware](http://tools.ietf.org/html/rfc2617) for Go. It is compatible with Go's own `net/http`, [goji](https://goji.io), Gin & anything that speaks the `http.Handler` interface.
+
+## Example
+
+`httpauth` provides a `SimpleBasicAuth` function to get you up and running. Particularly ideal for development servers.
+
+Note that HTTP Basic Authentication credentials are sent over the wire "in the clear" (read: plaintext!) and therefore should not be considered a robust way to secure a HTTP server. If you're after that, you'll need to use SSL/TLS ("HTTPS") at a minimum.
+
+### Install It
+
+```sh
+$ go get github.com/goji/httpauth
+```
+
+### Goji v2
+
+#### Simple Usage
+
+The fastest and simplest way to get started using `httpauth` is to use the
+`SimpleBasicAuth` function.
+
+```go
+
+package main
+
+import(
+    "net/http"
+
+    "goji.io"
+)
+
+func main() {
+    mux := goji.NewMux()
+
+    mux.Use(httpauth.SimpleBasicAuth("dave", "somepassword"))
+    mux.Use(SomeOtherMiddleware)
+
+    // YourHandler now requires HTTP Basic Auth
+    mux.Handle(pat.Get("/some-route"), YourHandler))
+
+    log.Fatal(http.ListenAndServe("localhost:8000", mux))
+}
+```
+
+#### Advanced Usage
+
+For more control over the process, pass a `AuthOptions` struct to `BasicAuth` instead. This allows you to:
+
+* Configure the authentication realm.
+* Provide your own UnauthorizedHandler (anything that satisfies `http.Handler`) so you can return a better looking 401 page.
+* Define a custom authentication function, which is discussed in the next section.
+
+```go
+
+func main() {
+
+    authOpts := httpauth.AuthOptions{
+        Realm: "DevCo",
+        User: "dave",
+        Password: "plaintext!",
+        UnauthorizedHandler: myUnauthorizedHandler,
+    }
+
+    mux := goji.NewMux()
+
+    mux.Use(BasicAuth(authOpts))
+    mux.Use(SomeOtherMiddleware)
+
+    mux.Handle(pat.Get("/some-route"), YourHandler))
+
+    log.Fatal(http.ListenAndServe("localhost:8000", mux))
+}
+```
+
+#### Custom Authentication Function
+
+`httpauth` will accept a custom authentication function.
+Normally, you would not set `AuthOptions.User` nor `AuthOptions.Password` in this scenario.
+You would instead validate the given credentials against an external system such as a database.
+The contrived example below is for demonstration purposes only.
+
+```go
+func main() {
+
+    authOpts := httpauth.AuthOptions{
+        Realm: "DevCo",
+        AuthFunc: myAuthFunc,
+        UnauthorizedHandler: myUnauthorizedHandler,
+    }
+
+    mux := goji.NewMux()
+
+    mux.Use(BasicAuth(authOpts))
+    mux.Use(SomeOtherMiddleware)
+
+    mux.Handle(pat.Get("/some-route"), YourHandler))
+
+    log.Fatal(http.ListenAndServe("localhost:8000", mux))
+}
+
+// myAuthFunc is not secure.  It checks to see if the password is simply
+// the username repeated three times.
+func myAuthFunc(user, pass string, r *http.Request) bool {
+    return pass == strings.Repeat(user, 3)
+}
+```
+
+### gorilla/mux
+
+Since it's all `http.Handler`, `httpauth` works with [gorilla/mux](https://github.com/gorilla/mux) (and most other routers) as well:
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/goji/httpauth"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/", YourHandler)
+	http.Handle("/", httpauth.SimpleBasicAuth("dave", "somepassword")(r))
+
+	http.ListenAndServe(":7000", nil)
+}
+
+func YourHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Gorilla!\n"))
+}
+```
+
+### net/http
+
+If you're using vanilla `net/http`:
+
+```go
+package main
+
+import(
+	"net/http"
+
+	"github.com/goji/httpauth"
+)
+
+func main() {
+	http.Handle("/", httpauth.SimpleBasicAuth("dave", "somepassword")(http.HandlerFunc(YourHandler)))
+	http.ListenAndServe(":7000", nil)
+}
+```
+
+## Contributing
+
+Send a pull request! Note that features on the (informal) roadmap include HTTP Digest Auth.
+
+## License
+
+MIT Licensed. See the LICENSE file for details.

--- a/vendor/github.com/goji/httpauth/basic_auth.go
+++ b/vendor/github.com/goji/httpauth/basic_auth.go
@@ -1,0 +1,185 @@
+package httpauth
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type basicAuth struct {
+	h    http.Handler
+	opts AuthOptions
+}
+
+// AuthOptions stores the configuration for HTTP Basic Authentication.
+//
+// A http.Handler may also be passed to UnauthorizedHandler to override the
+// default error handler if you wish to serve a custom template/response.
+type AuthOptions struct {
+	Realm               string
+	User                string
+	Password            string
+	AuthFunc            func(string, string, *http.Request) bool
+	UnauthorizedHandler http.Handler
+}
+
+// Satisfies the http.Handler interface for basicAuth.
+func (b basicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check if we have a user-provided error handler, else set a default
+	if b.opts.UnauthorizedHandler == nil {
+		b.opts.UnauthorizedHandler = http.HandlerFunc(defaultUnauthorizedHandler)
+	}
+
+	// Check that the provided details match
+	if b.authenticate(r) == false {
+		b.requestAuth(w, r)
+		return
+	}
+
+	// Call the next handler on success.
+	b.h.ServeHTTP(w, r)
+}
+
+// authenticate retrieves and then validates the user:password combination provided in
+// the request header. Returns 'false' if the user has not successfully authenticated.
+func (b *basicAuth) authenticate(r *http.Request) bool {
+	const basicScheme string = "Basic "
+
+	if r == nil {
+		return false
+	}
+
+	// In simple mode, prevent authentication with empty credentials if User is
+	// not set. Allow empty passwords to support non-password use-cases.
+	if b.opts.AuthFunc == nil && b.opts.User == "" {
+		return false
+	}
+
+	// Confirm the request is sending Basic Authentication credentials.
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, basicScheme) {
+		return false
+	}
+
+	// Get the plain-text username and password from the request.
+	// The first six characters are skipped - e.g. "Basic ".
+	str, err := base64.StdEncoding.DecodeString(auth[len(basicScheme):])
+	if err != nil {
+		return false
+	}
+
+	// Split on the first ":" character only, with any subsequent colons assumed to be part
+	// of the password. Note that the RFC2617 standard does not place any limitations on
+	// allowable characters in the password.
+	creds := bytes.SplitN(str, []byte(":"), 2)
+
+	if len(creds) != 2 {
+		return false
+	}
+
+	givenUser := string(creds[0])
+	givenPass := string(creds[1])
+
+	// Default to Simple mode if no AuthFunc is defined.
+	if b.opts.AuthFunc == nil {
+		b.opts.AuthFunc = b.simpleBasicAuthFunc
+	}
+
+	return b.opts.AuthFunc(givenUser, givenPass, r)
+}
+
+// simpleBasicAuthFunc authenticates the supplied username and password against
+// the User and Password set in the Options struct.
+func (b *basicAuth) simpleBasicAuthFunc(user, pass string, r *http.Request) bool {
+	// Equalize lengths of supplied and required credentials
+	// by hashing them
+	givenUser := sha256.Sum256([]byte(user))
+	givenPass := sha256.Sum256([]byte(pass))
+	requiredUser := sha256.Sum256([]byte(b.opts.User))
+	requiredPass := sha256.Sum256([]byte(b.opts.Password))
+
+	// Compare the supplied credentials to those set in our options
+	if subtle.ConstantTimeCompare(givenUser[:], requiredUser[:]) == 1 &&
+		subtle.ConstantTimeCompare(givenPass[:], requiredPass[:]) == 1 {
+		return true
+	}
+
+	return false
+}
+
+// Require authentication, and serve our error handler otherwise.
+func (b *basicAuth) requestAuth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm=%q`, b.opts.Realm))
+	b.opts.UnauthorizedHandler.ServeHTTP(w, r)
+}
+
+// defaultUnauthorizedHandler provides a default HTTP 401 Unauthorized response.
+func defaultUnauthorizedHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}
+
+// BasicAuth provides HTTP middleware for protecting URIs with HTTP Basic Authentication
+// as per RFC 2617. The server authenticates a user:password combination provided in the
+// "Authorization" HTTP header.
+//
+// Example:
+//
+//     package main
+//
+//     import(
+//            "net/http"
+//            "github.com/zenazn/goji"
+//            "github.com/goji/httpauth"
+//     )
+//
+//     func main() {
+//          basicOpts := httpauth.AuthOptions{
+//                      Realm: "Restricted",
+//                      User: "Dave",
+//                      Password: "ClearText",
+//                  }
+//
+//          goji.Use(httpauth.BasicAuth(basicOpts), SomeOtherMiddleware)
+//          goji.Get("/thing", myHandler)
+//  }
+//
+// Note: HTTP Basic Authentication credentials are sent in plain text, and therefore it does
+// not make for a wholly secure authentication mechanism. You should serve your content over
+// HTTPS to mitigate this, noting that "Basic Authentication" is meant to be just that: basic!
+func BasicAuth(o AuthOptions) func(http.Handler) http.Handler {
+	fn := func(h http.Handler) http.Handler {
+		return basicAuth{h, o}
+	}
+	return fn
+}
+
+// SimpleBasicAuth is a convenience wrapper around BasicAuth. It takes a user and password, and
+// returns a pre-configured BasicAuth handler using the "Restricted" realm and a default 401 handler.
+//
+// Example:
+//
+//     package main
+//
+//     import(
+//            "net/http"
+//            "github.com/zenazn/goji/web/httpauth"
+//     )
+//
+//     func main() {
+//
+//          goji.Use(httpauth.SimpleBasicAuth("dave", "somepassword"), SomeOtherMiddleware)
+//          goji.Get("/thing", myHandler)
+//      }
+//
+func SimpleBasicAuth(user, password string) func(http.Handler) http.Handler {
+	opts := AuthOptions{
+		Realm:    "Restricted",
+		User:     user,
+		Password: password,
+	}
+	return BasicAuth(opts)
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -24,14 +24,9 @@ type Status struct {
 	LastFinished time.Time
 	// Idle stands for whether worker is idle, false if syncing
 	Idle bool
-	// Stdout records outputs to stdout of each command execution
-	// TODO: This slice may grow quite large as time goes by
-	// Candidate solutions:
-	// - use compression method like gzip/zlib [logs tend to have high compression rate, but just workaround]
-	// - keep max-length and remove exceeded items [frequent memory operation, stop-the-world GC]
-	// Anyway, a new type needs to be implemented/imported with Put(string) and GetAll() []string method
+	// Last stdout(s) for admin. Internal implementation may vary to provide it in Status()
 	Stdout []string
-	// Stderr records outputs to stderr of each command execution
+	// Last stderr(s) for admin. Internal implementation may vary to provide it in Status()
 	Stderr []string
 }
 
@@ -41,7 +36,13 @@ func NewWorker(cfg config.RepoConfig) (Worker, error) {
 		switch syncType {
 		case "rsync":
 			w, err := NewRsyncWorker(
-				&Status{Result: true, LastFinished: time.Now(), Idle: true},
+				Status{
+					Result:       true,
+					LastFinished: time.Now(),
+					Idle:         true,
+					Stdout:       make([]string, 0),
+					Stderr:       make([]string, 0),
+				},
 				cfg,
 				make(chan int))
 			if err != nil {
@@ -50,7 +51,13 @@ func NewWorker(cfg config.RepoConfig) (Worker, error) {
 			return w, nil
 		case "shell_script":
 			w, err := NewShellScriptWorker(
-				&Status{Result: true, LastFinished: time.Now(), Idle: true},
+				Status{
+					Result:       true,
+					LastFinished: time.Now(),
+					Idle:         true,
+					Stdout:       make([]string, 0),
+					Stderr:       make([]string, 0),
+				},
 				cfg,
 				make(chan int))
 			if err != nil {


### PR DESCRIPTION
1. `helper.MaxLengthSlice` was implemented to limit the max size of log buffer. The maximum is hard-coded at `NewFooWorker` with value 200.
2. Add HTTP basic auth support for JSON API. The username & password could be specified by `-u` and `-p` command line options.
3. Add tests for `maxlengthsize` & `rlimit`.
4. Add autocompletion script for zsh.
