### PR TITLE
shell_script_worker: fix command-line segmentation

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a5b447f471772232fe70aa83e4cf7eec38c00fe5581327c55fb2be62bc61653b
-updated: 2018-01-29T17:59:29.567458566+08:00
+hash: 32449d377f20bbba2a9e1d7b12e728b6a4d83a64e9a3d05dd1b6e19addc1e378
+updated: 2018-02-02T23:17:15.808114381+08:00
 imports:
 - name: github.com/ant0ine/go-json-rest
   version: 3a807d6d8d36e0f9175d6c292030fce09bcbb2db
@@ -12,6 +12,8 @@ imports:
   - quantile
 - name: github.com/bshuster-repo/logrus-logstash-hook
   version: f8b7f00a4feb2088e5f7290f1c9360d1081ba0b5
+- name: github.com/cosiner/argv
+  version: 13bacc38a0a5e0eba18b6f03cbb15dc5d4243b04
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,3 +35,4 @@ import:
   version: ^0.9.0-pre1
   subpackages:
   - prometheus/promhttp
+- package: github.com/cosiner/argv

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"io"
 	"os/exec"
+	"time"
 )
 
 var rsyncW Worker
@@ -92,3 +93,27 @@ func TestUtilityRlimit(t *testing.T) {
 	}
 	assert.True(err1 != nil || err2 != nil)
 }
+
+func TestShellScriptWorkerArgParse(t *testing.T) {
+	c := map[string]string {
+		"type": "shell_script",
+		"name": "shell",
+		"script": "wc -l /proc/stat",
+	}
+	w, err := NewWorker(c)
+
+	asrt := assert.New(t)
+	asrt.Nil(err)
+
+	go w.RunSync()
+	// workarounds
+	time.Sleep(time.Millisecond * 500)
+	w.TriggerSync()
+	time.Sleep(time.Millisecond * 500)
+	for ;!w.GetStatus().Idle; {
+		time.Sleep(time.Millisecond * 500)
+	}
+	asrt.True(w.GetStatus().Idle)
+	asrt.True(w.GetStatus().Result)
+}
+


### PR DESCRIPTION
Use `argv` to parse string into arguments.

- environment variables are supported: `bash run_something.sh $HOME`
- backquotes/`$()` are supported: `bash run_something.sh $(which ls)`
- pipes are not supported: An runtime error will be raised

Fixes #19