### PR TITLE
test: worker: fix occasional TestUtilityRlimit failure

### DIFF
--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -72,7 +72,7 @@ func (i *limitReader) Read(p []byte) (int, error) {
 	}
 	i.cnt += len(p)
 	for i := 0; i < len(p); i++ {
-		p[i] = 0
+		p[i] = 5 // shouldn't use zero here, because sometimes pages filled with zero are not allocated
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
The failure is caused by limitReader, originally designed to
feed limit bytes into the rev program and stress the memory.
Previous implementation feeds zero, which causes the page are not
actually allocated in some cases. This patch changes it to 5,
a magic number.

Fixes #21 