### PR TITLE
support external worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ docker run -d -v {{host_path}}:{{docker_path}} -v {{absolute_path_of_config.yaml
 ```
 
 ### config.yaml
+
+The below configuration may be outdated. Refer to [config.example.yaml](https://github.com/sjtug/lug/blob/master/config.example.yaml)
+and [Wiki](https://github.com/sjtug/lug/wiki/Configuration) for the latest version.
+
 ```
 interval: 3 # Interval between pollings
 loglevel: 5 # 0-5. 0 for ERROR and 5 for DEBUG

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,3 +7,6 @@ repos:
       interval: 6
       path: /tmp/putty
       name: putty
+    - type: external
+      name: external_worker
+      customized_key: any_value_parsed_by_external_program

--- a/worker/external_worker.go
+++ b/worker/external_worker.go
@@ -1,0 +1,50 @@
+package worker
+
+import (
+	"errors"
+	"github.com/Sirupsen/logrus"
+	"github.com/sjtug/lug/config"
+	"time"
+)
+
+// ExternalWorker is a stub worker which always returns
+// {Idle: false, Result: true}.
+type ExternalWorker struct {
+	name   string
+	logger *logrus.Entry
+	cfg    config.RepoConfig
+}
+
+func NewExternalWorker(cfg config.RepoConfig) (*ExternalWorker, error) {
+	name, ok := cfg["name"]
+	if !ok {
+		return nil, errors.New("Name is required for external worker")
+	}
+	return &ExternalWorker{
+		name:   name,
+		logger: logrus.WithField("worker", name),
+		cfg:    cfg,
+	}, nil
+}
+
+func (ew *ExternalWorker) GetStatus() Status {
+	return Status{
+		Result:       true,
+		LastFinished: time.Now(),
+		Idle:         false,
+		Stdout:       []string{},
+		Stderr:       []string{},
+	}
+}
+
+func (ew *ExternalWorker) RunSync() {
+	// a for {} should not be used here since it occupies 100% CPU
+	select {}
+}
+
+func (ew *ExternalWorker) TriggerSync() {
+}
+
+func (ew *ExternalWorker) GetConfig() config.RepoConfig {
+	return ew.cfg
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -64,6 +64,12 @@ func NewWorker(cfg config.RepoConfig) (Worker, error) {
 				return nil, err
 			}
 			return w, nil
+		case "external":
+			w, err := NewExternalWorker(cfg)
+			if err != nil {
+				return nil, err
+			}
+			return w, nil
 		}
 	}
 	return nil, errors.New("Fail to create a new worker")

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -12,6 +12,28 @@ import (
 
 var rsyncW Worker
 
+func TestNewExternalWorker(t *testing.T) {
+	asrt := assert.New(t)
+	c := config.RepoConfig{
+		"blahblah": "foobar",
+		"type":     "external",
+	}
+	_, err := NewWorker(c)
+	// worker with no name is not allowed
+	asrt.NotNil(err)
+
+	c["name"] = "test_external"
+	w, err := NewWorker(c)
+	// config with name and dummy kv pairs should be allowed
+	asrt.Nil(err)
+
+	status := w.GetStatus()
+	asrt.True(status.Result)
+	asrt.False(status.Idle)
+	asrt.NotNil(status.Stderr)
+	asrt.NotNil(status.Stdout)
+}
+
 func TestNewRsyncWorker(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Fixes #17 

external worker delegates all work to external programs.
lug only returns a stub status in GET /manager.