### PR TITLE
Improve remote logging system

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,10 @@ loglevel: 5 # 1-5
 # Prometheus metrics are exposed at http://exporter_address/metrics
 exporter_address: :8081
 
-## logstash sink. Lug will send all logs to this address
-# logstash_address: logstash.metrics.foobar.com:1234
+#logstash:
+#   address: listener.logz.io:5050 # logstash sink. Lug will send all logs to this address
+#   additional_fields:
+#       token: "" # Additional fields sent to logstash server
 
 # Address where JSON API will be served
 json_api:

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ package config
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"io"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -25,14 +25,19 @@ type JsonAPIConfig struct {
 	KeyFile string
 }
 
+type LogStashConfig struct {
+	Address          string
+	AdditionalFields map[string]interface{} `mapstructure:"additional_fields"`
+}
+
 // Config stores all configuration of lug
 type Config struct {
 	// Interval between pollings in manager
 	Interval int
 	// LogLevel: 0-5 is acceptable
 	LogLevel log.Level
-	// LogStashAddr represents the address of logstash
-	LogStashAddr string `mapstructure:"logstash_address"`
+	// LogStashConfig represents configurations for logstash
+	LogStashConfig LogStashConfig `mapstructure:"logstash"`
 	// ExporterAddr is the address to expose metrics, :8080 for default
 	ExporterAddr string `mapstructure:"exporter_address"`
 	// JsonAPIConfig specifies configuration of JSON restful API

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -2,7 +2,7 @@
 package exporter
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sjtug/lug/helper"

--- a/glide.lock
+++ b/glide.lock
@@ -12,6 +12,8 @@ imports:
   - quantile
 - name: github.com/bshuster-repo/logrus-logstash-hook
   version: f8b7f00a4feb2088e5f7290f1c9360d1081ba0b5
+- name: github.com/cheshir/logrustash
+  version: d55d6adc72cff4345182c78983cf8f42e2bc294d
 - name: github.com/cosiner/argv
   version: 13bacc38a0a5e0eba18b6f03cbb15dc5d4243b04
 - name: github.com/davecgh/go-spew

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6c3346466d8768c10b1f6326f481cc5cad97fda14abad486b8fa7915a6acccd9
-updated: 2018-02-13T20:11:25.817552035+08:00
+hash: c408e7244a2aa61f00a89da11b974d020fb3e86b8f8978fc88a69915e07922c4
+updated: 2018-02-13T21:26:41.425149652+08:00
 imports:
 - name: github.com/ant0ine/go-json-rest
   version: 3a807d6d8d36e0f9175d6c292030fce09bcbb2db
@@ -74,7 +74,7 @@ imports:
   - internal/util
   - nfs
   - xfs
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/afero
   version: bbf41cb36dffe15dff5bf7e18c447801e7ffe163

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/sjtug/lug
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: a283a10442df8dc09befd873fab202bf8a253d6a
 - package: github.com/ant0ine/go-json-rest
   version: 3a807d6d8d36e0f9175d6c292030fce09bcbb2db

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,8 +7,6 @@ import:
   subpackages:
   - rest
   - rest/trie
-- package: github.com/bshuster-repo/logrus-logstash-hook
-  version: f8b7f00a4feb2088e5f7290f1c9360d1081ba0b5
 - package: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -40,3 +38,5 @@ import:
   version: ~1.0.0
 - package: github.com/spf13/pflag
   version: ~1.0.0
+- package: github.com/cheshir/logrustash
+  version: ~0.7.0

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"net/http"
 
-	"github.com/bshuster-repo/logrus-logstash-hook"
+	"github.com/cheshir/logrustash"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/goji/httpauth"
 	log "github.com/sirupsen/logrus"
@@ -13,6 +13,7 @@ import (
 	"github.com/sjtug/lug/exporter"
 	"github.com/sjtug/lug/manager"
 	"os"
+	"time"
 )
 
 const (
@@ -56,10 +57,14 @@ func getFlags() (flags CommandFlags) {
 func prepareLogger(logLevel log.Level, logStashAddr string) {
 	log.SetLevel(logLevel)
 	if logStashAddr != "" {
-		hook, err := logrus_logstash.NewHook("tcp", logStashAddr, "lug")
+		hook, err := logrustash.NewAsyncHook("tcp", logStashAddr, "lug")
 		if err != nil {
 			log.Fatal(err)
 		}
+		hook.WaitUntilBufferFrees = true
+		hook.ReconnectBaseDelay = time.Second
+		hook.ReconnectDelayMultiplier = 2
+		hook.MaxSendRetries = 10
 		log.AddHook(hook)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	flag "github.com/spf13/pflag"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/goji/httpauth"
+	log "github.com/sirupsen/logrus"
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/exporter"
 	"github.com/sjtug/lug/manager"

--- a/main.go
+++ b/main.go
@@ -54,10 +54,10 @@ func getFlags() (flags CommandFlags) {
 }
 
 // Register Logger and set logLevel
-func prepareLogger(logLevel log.Level, logStashAddr string) {
+func prepareLogger(logLevel log.Level, logStashAddr string, additionalFields map[string]interface{}) {
 	log.SetLevel(logLevel)
 	if logStashAddr != "" {
-		hook, err := logrustash.NewAsyncHook("tcp", logStashAddr, "lug")
+		hook, err := logrustash.NewAsyncHookWithFields("tcp", logStashAddr, "lug", additionalFields)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func init() {
 	cfg = config.Config{}
 	err = cfg.Parse(file)
 
-	prepareLogger(cfg.LogLevel, cfg.LogStashAddr)
+	prepareLogger(cfg.LogLevel, cfg.LogStashConfig.Address, cfg.LogStashConfig.AdditionalFields)
 	log.Info("Starting...")
 	log.Debugln(spew.Sdump(cfg))
 	if err != nil {

--- a/manager/json_rest.go
+++ b/manager/json_rest.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/ant0ine/go-json-rest/rest"
 	"net/http"
 	"time"

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -2,7 +2,7 @@
 package manager
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/worker"
 	"strconv"

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -2,7 +2,7 @@ package manager
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
 

--- a/worker/external_worker.go
+++ b/worker/external_worker.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"errors"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/sjtug/lug/config"
 	"time"
 )

--- a/worker/rsync_worker.go
+++ b/worker/rsync_worker.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"bytes"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/exporter"
 	"github.com/sjtug/lug/helper"

--- a/worker/shell_script_worker.go
+++ b/worker/shell_script_worker.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"bytes"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cosiner/argv"
 	"github.com/sjtug/lug/config"
 	"github.com/sjtug/lug/exporter"


### PR DESCRIPTION
This PR performs the following changes:
- [x] Fix renamed package: `github.com/Sirupsen/logrus/` => `github.com/sirupsen/logrus/`
- [x] Replace deprecated `logrus-logstash-hook` with [`logrustash`](https://github.com/cheshir/logrustash)
- [x] Remote logging is asynchronous now
- [x] Configurable additional field(s) sent to logstash
