### PR TITLE
Restart sync at the start of lug

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -40,8 +40,9 @@ func NewWorker(cfg config.RepoConfig) (Worker, error) {
 		case "rsync":
 			w, err := NewRsyncWorker(
 				Status{
-					Result:       true,
-					LastFinished: time.Now(),
+					Result: true,
+					// here we set lastFinished to a very small value to ensure immediate trigger after restart
+					LastFinished: time.Now().AddDate(-1, 0, 0),
 					Idle:         true,
 					Stdout:       make([]string, 0),
 					Stderr:       make([]string, 0),
@@ -56,7 +57,7 @@ func NewWorker(cfg config.RepoConfig) (Worker, error) {
 			w, err := NewShellScriptWorker(
 				Status{
 					Result:       true,
-					LastFinished: time.Now(),
+					LastFinished: time.Now().AddDate(-1, 0, 0),
 					Idle:         true,
 					Stdout:       make([]string, 0),
 					Stderr:       make([]string, 0),


### PR DESCRIPTION
Internally, this is implemented by setting the initial value of `lastFinished` to a value small value (1 year ago).