### PR TITLE
improve rsyncWorker params about partial files

### DIFF
--- a/worker/rsync_worker.go
+++ b/worker/rsync_worker.go
@@ -102,9 +102,16 @@ func (w *RsyncWorker) RunSync() {
 		w.logger.WithField("event", "signal_received").Debug("finished waiting for signal")
 		src, _ := w.cfg["source"]
 		dst, _ := w.cfg["path"]
-		cmd := exec.Command("rsync", "-aHvh", "--no-o", "--no-g", "--stats",
-			"--delete", "--delete-delay", "--safe-links",
-			"--timeout=120", "--contimeout=120", src, dst)
+		rsyncParams := []string{
+			"-aHvh", "--no-o", "--no-g", "--stats",
+			"--delete", "--delete-delay", "--safe-links", "--partial-dir=.rsync-partial",
+			"--timeout=120", "--contimeout=120",
+		}
+		if _, ok := w.cfg["exclude_hidden"]; ok {
+			rsyncParams = append(rsyncParams, "--exclude=.*")
+		}
+		rsyncParams = append(rsyncParams, src, dst)
+		cmd := exec.Command("rsync", rsyncParams...)
 		var bufErr, bufOut bytes.Buffer
 		cmd.Stdout = &bufOut
 		cmd.Stderr = &bufErr

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -50,6 +50,7 @@ func TestNewRsyncWorker(t *testing.T) {
 	c["path"] = "/tmp/putty"
 	c["interval"] = "6"
 	c["rlimit_mem"] = "10M"
+	c["exclude_hidden"] = "true"
 	rsyncW, _ = NewWorker(c)
 
 	asrt.True(rsyncW.GetStatus().Result)
@@ -57,6 +58,7 @@ func TestNewRsyncWorker(t *testing.T) {
 	asrt.Equal("rsync", rsyncW.GetConfig()["type"])
 	asrt.Equal("putty", rsyncW.GetConfig()["name"])
 	asrt.Equal("source: rsync://rsync.chiark.greenend.org.uk/ftp/users/sgtatham/putty-website-mirror/", rsyncW.GetConfig()["source"])
+	asrt.Equal("true", rsyncW.GetConfig()["exclude_hidden"])
 	asrt.Equal("/tmp/putty", rsyncW.GetConfig()["path"])
 
 }


### PR DESCRIPTION
- `--partial-dirs` is now specified as `.rsync-partial` to avoid pollution
    to downstream
- rsyncWorker now supports a key called `exclude_hidden`. When
    specified, this key indicates rsync to exclude hidden files
    from upstream