### PR TITLE
implement concurrent_limit

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -206,6 +206,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2549d7e954f95b5124420f3dd486cd1c1770b4844853b1cafd3a861a4852a490"
+  inputs-digest = "ccf2bd6502f23ecbce60ec05f54127b2c530aa64946cc0982a2788e05f086e6b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,3 +52,6 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/davecgh/go-spew"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,6 @@
 interval: 3 # Interval between pollings
 loglevel: 5 # 1-5
+concurrent_limit: 1 # Maximum worker that can run at the same time
 # Prometheus metrics are exposed at http://exporter_address/metrics
 exporter_address: :8081
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,12 +17,15 @@ repos:
     - type: shell_script
       script: rsync -av rsync://rsync.chiark.greenend.org.uk/ftp/users/sgtatham/putty-website-mirror/ /tmp/putty
       name: putty
+      interval: 600
     - type: shell_script
       script: bash -c 'printenv | grep ^LUG'
       name: printenv
       any_option: any_value
       any_switch: true # This will be set to 1
       any_switch_2: false # unset
+      interval: 10
     - type: external
       name: ubuntu
       proxy_to: http://ftp.sjtu.edu.cn/ubuntu/
+      # Since interval is not set for this target, this will only be triggered at startup

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	Interval int
 	// LogLevel: 0-5 is acceptable
 	LogLevel log.Level
+	// ConcurrentLimit: how many worker can run at the same time
+	ConcurrentLimit int `mapstructure:"concurrent_limit"`
 	// LogStashConfig represents configurations for logstash
 	LogStashConfig LogStashConfig `mapstructure:"logstash"`
 	// ExporterAddr is the address to expose metrics, :8080 for default
@@ -49,6 +51,7 @@ func init() {
 	CfgViper.SetDefault("loglevel", 4)
 	CfgViper.SetDefault("json_api.address", ":7001")
 	CfgViper.SetDefault("exporter_address", ":8080")
+	CfgViper.SetDefault("concurrent_limit", 5)
 }
 
 // Parse creates config from a reader
@@ -65,6 +68,9 @@ func (c *Config) Parse(in io.Reader) (err error) {
 		}
 		if c.LogLevel < 0 || c.LogLevel > 5 {
 			return errors.New("loglevel must be 0-5")
+		}
+		if c.ConcurrentLimit <= 0 {
+			return errors.New("concurrent limit must be positive")
 		}
 	}
 	for _, repo := range c.Repos {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,6 +10,7 @@ import (
 func TestParseConfig(t *testing.T) {
 	const testStr = `interval: 25
 loglevel: 5 # 1 - 5
+concurrent_limit: 6
 repos:
 - type: shell_script
   script: rsync -av rsync://rsync.chiark.greenend.org.uk/ftp/users/sgtatham/putty-website-mirror/ /tmp/putty
@@ -24,6 +25,7 @@ repos:
 	asrt.Equal(25, c.Interval)
 	asrt.Equal(5, int(c.LogLevel))
 	asrt.Equal(1, len(c.Repos))
+	asrt.Equal(6, c.ConcurrentLimit)
 	asrt.EqualValues("shell_script", c.Repos[0]["type"])
 	asrt.EqualValues("rsync -av rsync://rsync.chiark.greenend.org.uk/ftp/users/sgtatham/putty-website-mirror/ /tmp/putty", c.Repos[0]["script"])
 	asrt.EqualValues("/mnt/putty", c.Repos[0]["path"])
@@ -81,4 +83,18 @@ repos:
 	err = c.Parse(strings.NewReader(testStr))
 
 	asrt.Equal("loglevel must be 0-5", err.Error())
+
+	testStr = `interval: 25
+loglevel: 4
+concurrent_limit: 0
+repos:
+- type: shell_script
+  script: rsync -av rsync://rsync.chiark.greenend.org.uk/ftp/users/sgtatham/putty-website-mirror/ /tmp/putty
+  name: putty
+  path: /mnt/putty
+`
+	c = Config{}
+	err = c.Parse(strings.NewReader(testStr))
+
+	asrt.Equal("concurrent limit must be positive", err.Error())
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -141,7 +141,10 @@ func (m *Manager) Run() {
 					}
 					wConfig := w.GetConfig()
 					elapsed := time.Since(m.workersLastInvokeTime[i])
-					sec2sync, _ := wConfig["interval"].(int)
+					sec2sync, ok := wConfig["interval"].(int)
+					if !ok {
+						sec2sync = 31536000 // if "interval" is not specified, then worker will launch once a year
+					}
 					if !m.isAlreadyInPendingQueue(i) && elapsed > time.Duration(sec2sync)*time.Second {
 						m.logger.WithFields(logrus.Fields{
 							"event":                  "trigger_pending",

--- a/pkg/worker/external_worker.go
+++ b/pkg/worker/external_worker.go
@@ -34,7 +34,7 @@ func (ew *ExternalWorker) GetStatus() Status {
 	return Status{
 		Result:       true,
 		LastFinished: time.Now(),
-		Idle:         false,
+		Idle:         true,
 		Stdout:       []string{},
 		Stderr:       []string{},
 	}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -31,7 +31,7 @@ func TestNewExternalWorker(t *testing.T) {
 
 	status := w.GetStatus()
 	asrt.True(status.Result)
-	asrt.False(status.Idle)
+	asrt.True(status.Idle)
 	asrt.NotNil(status.Stderr)
 	asrt.NotNil(status.Stdout)
 }


### PR DESCRIPTION
Fixed #60 .

Unsolved problem:
- [x] ~~how to handle `external worker`~~? 
  - **This was solved by marking them as idle, but set the default interval to 1y**
  - If they are always marked as `running`, then they may be calculated into `running_worker_cnt`, so normal workers may never have a chance to launch. 
  - If they are marked as `idle`, then they will always be submitted to `pendingQueue` on each poll. In worst cases, every normal worker has to wait for `N_external_worker / concurrent_limit` turns before launch.

**Breaking changes**:
- Now `external worker` by default returns `idle: True`
- Worker with unspecified `interval` will now be triggered once a year and at startup, instead of being triggered at every poll