### PR TITLE
manager: allow disable repos

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -58,7 +58,7 @@ func NewManager(config *config.Config) (*Manager, error) {
 		logger:                logrus.WithField("manager", ""),
 	}
 	for _, repoConfig := range config.Repos {
-		if repoConfig["disabled"] == true {
+		if disabled, ok := repoConfig["disabled"].(bool); ok && disabled {
 			continue
 		}
 		w, err := worker.NewWorker(repoConfig)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -62,6 +62,9 @@ func NewManager(config *config.Config) (*Manager, error) {
 		if err != nil {
 			return nil, err
 		}
+		if w.GetConfig()["disabled"] == true {
+			continue
+		}
 		newManager.workers = append(newManager.workers, w)
 		newManager.workersLastInvokeTime = append(newManager.workersLastInvokeTime, time.Now().AddDate(-1, 0, 0))
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -58,12 +58,12 @@ func NewManager(config *config.Config) (*Manager, error) {
 		logger:                logrus.WithField("manager", ""),
 	}
 	for _, repoConfig := range config.Repos {
+		if repoConfig["disabled"] == true {
+			continue
+		}
 		w, err := worker.NewWorker(repoConfig)
 		if err != nil {
 			return nil, err
-		}
-		if w.GetConfig()["disabled"] == true {
-			continue
 		}
 		newManager.workers = append(newManager.workers, w)
 		newManager.workersLastInvokeTime = append(newManager.workersLastInvokeTime, time.Now().AddDate(-1, 0, 0))


### PR DESCRIPTION
This PR adds `disabled` option for lug repo. If `disabled` is true, lug won't show and handle this repo in JSON API. This means caddy is enough to handle this repo.