### PR TITLE
chore: replace deprecated apis

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -220,7 +220,13 @@ func (m *Manager) Run() {
 		}).Debugf("Calling RunSync() to w %s", w.GetConfig()["name"])
 		go w.RunSync()
 	}
-	m.checkpoint()
+	err := m.checkpoint()
+	if err != nil {
+		m.logger.WithFields(logrus.Fields{
+			"event": "checkpoint_failed",
+			"error": err,
+		}).Error("Failed to checkpoint")
+	}
 	for {
 		// wait until config.Interval seconds has elapsed
 		select {
@@ -264,7 +270,13 @@ func (m *Manager) Run() {
 				// Here we do not checkpoint very concisely (e.g. every time after a successful sync).
 				// We just want to minimize re-sync after restarting lug.
 				if shouldCheckpoint {
-					m.checkpoint()
+					err := m.checkpoint()
+					if err != nil {
+						m.logger.WithFields(logrus.Fields{
+							"event": "checkpoint_failed",
+							"error": err,
+						}).Error("Failed to checkpoint")
+					}
 				}
 			}
 		case sig, ok := <-m.controlChan:

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -34,7 +34,7 @@ type Status struct {
 }
 
 // NewWorker generates a worker by config and log.
-func NewWorker(cfg config.RepoConfig, lastFinished time.Time) (Worker, error) {
+func NewWorker(cfg config.RepoConfig, lastFinished time.Time, Result bool) (Worker, error) {
 	if syncType, ok := cfg["type"]; ok {
 		switch syncType {
 		case "rsync":
@@ -44,7 +44,7 @@ func NewWorker(cfg config.RepoConfig, lastFinished time.Time) (Worker, error) {
 			w, err := NewExecutorInvokeWorker(
 				newShellScriptExecutor(cfg),
 				Status{
-					Result:       true,
+					Result:       Result,
 					LastFinished: lastFinished,
 					Idle:         true,
 					Stdout:       make([]string, 0),

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -24,12 +24,12 @@ func TestNewExternalWorker(t *testing.T) {
 		"blahblah": "foobar",
 		"type":     "external",
 	}
-	_, err := NewWorker(c, time.Now())
+	_, err := NewWorker(c, time.Now(), true)
 	// worker with no name is not allowed
 	asrt.NotNil(err)
 
 	c["name"] = "test_external"
-	w, err := NewWorker(c, time.Now())
+	w, err := NewWorker(c, time.Now(), true)
 	// config with name and dummy kv pairs should be allowed
 	asrt.Nil(err)
 
@@ -48,7 +48,7 @@ func TestNewShellScriptWorker(t *testing.T) {
 
 	asrt := assert.New(t)
 
-	w, _ := NewWorker(c, time.Now())
+	w, _ := NewWorker(c, time.Now(), true)
 
 	asrt.Equal(true, w.GetStatus().Result)
 	asrt.Equal("shell_script", w.GetConfig()["type"])
@@ -187,7 +187,7 @@ func TestShellScriptWorkerArgParse(t *testing.T) {
 		"name":   "shell",
 		"script": "wc -l /proc/stat",
 	}
-	w, err := NewWorker(c, time.Now())
+	w, err := NewWorker(c, time.Now(), true)
 
 	asrt := assert.New(t)
 	asrt.Nil(err)


### PR DESCRIPTION
Preserve the sync result and the last successful sync time of each repository between server reloads.